### PR TITLE
feat: Add automatic AI matching for Dispatcharr channels

### DIFF
--- a/lib/ui/menus.sh
+++ b/lib/ui/menus.sh
@@ -404,7 +404,8 @@ show_dispatcharr_stationid_menu() {
     stationid_options=(
         "a|Scan Channels for Missing Station IDs"
         "b|Interactive Station ID Matching"
-        "c|Commit Station ID Changes"
+        "c|Automatic AI Station ID Matching"
+        "d|Commit Queued Station ID Changes"
         "q|Back to Dispatcharr Menu"
     )
     

--- a/readme.md
+++ b/readme.md
@@ -57,11 +57,11 @@ A comprehensive television station search tool that (optionally) integrates with
 - **Reverse Station ID Lookup**
 
 ### 🔧 **Integrations**
-- **AI-Powered Search** - Use natural language queries (e.g., "news channels in the uk") to find stations, powered by the Google Gemini API.
+- **AI-Powered Search** - Use natural language queries (e.g., "news channels in the uk") to find stations, powered by the Google Gemini API. This is available as a standalone search and within the Dispatcharr station matching workflow.
 - **Dispatcharr - Complete Channel Management** - Create, edit, update, and delete channels from search results
 - **Dispatcharr - Group Management** - View, create, modify, and delete channel groups
 - **Dispatcharr - Stream Management** - Search, assign, and remove streams with table-based UI
-- **Dispatcharr - Field Population and Station ID Matching** - Interactive matching for channels missing station IDs. Automatically populate channel name, TVG-ID, station ID, and logos
+- **Dispatcharr - Field Population and Station ID Matching** - Interactive and **fully automatic** matching for channels missing station IDs. Automatically populate channel name, TVG-ID, station ID, and logos
 - **Emby - Populate Missing listingIds** - Automatically find any missing listingIds and add them to Emby for rich EPG data
 - **Emby - Delete All Channel Numbers** - Useful for some users
 


### PR DESCRIPTION
This commit adds a new "Automatic AI Matching" feature to the Dispatcharr station ID workflow.

This new mode iterates through all channels missing a station ID and uses the Gemini AI parser to find potential matches in the local database. If a high-confidence match (exactly one result) is found, the station ID is applied automatically. Channels with ambiguous or no matches are skipped, allowing the user to process them manually later.

A summary report is displayed at the end of the process, showing the number of successful, skipped, and failed matches.